### PR TITLE
CON-4331 Use phpunit 5.7.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 
     "require-dev": {
         "behat/behat": "2.4.*@stable",
-        "phpunit/phpunit": ">=4.8.35 <6.*.*@stable",
+        "phpunit/phpunit": ">=4.8.35 <6@stable",
         "phake/phake": "@stable"
     },
 


### PR DESCRIPTION
phpunit 6 is not compatible with php 5.3 5.4 5.6
So we can't migrate to the latest version right now