### PR TITLE
CON-4731: Fix generating for c_revision

### DIFF
--- a/src/main/Shopware/Connect/RevisionProvider/Time.php
+++ b/src/main/Shopware/Connect/RevisionProvider/Time.php
@@ -38,8 +38,9 @@ class Time extends RevisionProvider
      */
     public function next()
     {
-        if (!isset($time)) {
+        if ($this->iteration > 99999 || !isset($this->time)) {
             $this->time = microtime(true);
+            $this->iteration = 0;
         }
 
         return sprintf('%.5f%05d', $this->time, $this->iteration++);


### PR DESCRIPTION
While generating and syncing more than 2.000.000 products with the Connect-SDK, there exists a bug with generating the c_revision when the article counts over 100000.

The sprintf function formats the microtime and iteration-count so the generated string won't change and the unique index in the database throws an error on insert.