### PR TITLE
NTR: added error reporting

### DIFF
--- a/src/main/Shopware/Connect/Service/Shopping.php
+++ b/src/main/Shopware/Connect/Service/Shopping.php
@@ -134,8 +134,8 @@ class Shopping
             $shopGateway = $this->shopFactory->getShopGateway($shopId);
             $shopCheckResult = $shopGateway->checkProducts($order, $myShopId);
 
-            if (count($shopCheckResult)) {
-                $this->applyRemoteShopChanges($shopCheckResult);
+            if (count($shopCheckResult->changes)) {
+                $this->applyRemoteShopChanges($shopCheckResult->changes);
             }
 
             $checkResults[] = $shopCheckResult;

--- a/src/main/Shopware/Connect/Service/Shopping.php
+++ b/src/main/Shopware/Connect/Service/Shopping.php
@@ -134,8 +134,8 @@ class Shopping
             $shopGateway = $this->shopFactory->getShopGateway($shopId);
             $shopCheckResult = $shopGateway->checkProducts($order, $myShopId);
 
-            if (count($shopCheckResult->changes)) {
-                $this->applyRemoteShopChanges($shopCheckResult->changes);
+            if (count($shopCheckResult)) {
+                $this->applyRemoteShopChanges($shopCheckResult);
             }
 
             $checkResults[] = $shopCheckResult;

--- a/src/main/Shopware/Connect/ShopGateway/Http.php
+++ b/src/main/Shopware/Connect/ShopGateway/Http.php
@@ -83,7 +83,7 @@ class Http extends ShopGateway
      */
     public function checkProducts(Struct\Order $order, $shopId)
     {
-        return $this->makeRpcCall(
+        $result = $this->makeRpcCall(
             new RpcCall(
                 array(
                     'service' => 'transaction',
@@ -92,6 +92,12 @@ class Http extends ShopGateway
                 )
             )
         );
+
+        if ($result instanceof Struct\Error) {
+            throw new \Exception($result->message);
+        } else {
+            return $result;
+        }
     }
 
     /**

--- a/src/main/Shopware/Connect/ShopGateway/Http.php
+++ b/src/main/Shopware/Connect/ShopGateway/Http.php
@@ -77,9 +77,12 @@ class Http extends ShopGateway
      * Returns true on success, or an array of Struct\Change with updates for
      * the requested products.
      *
+     * Throws RuntimeException if something went wrong.
+     *
      * @param Struct\Order $order
      * @param string $shopId
      * @return mixed
+     * @throws \RuntimeException
      */
     public function checkProducts(Struct\Order $order, $shopId)
     {
@@ -93,10 +96,10 @@ class Http extends ShopGateway
             )
         );
         if ($result instanceof Struct\Error) {
-            throw new \Exception($result->message);
-        } else {
-            return $result;
+            throw new \RuntimeException($result->message);
         }
+
+        return $result;
     }
 
     /**

--- a/test/Shopware/Connect/ShopGateway/HttpTest.php
+++ b/test/Shopware/Connect/ShopGateway/HttpTest.php
@@ -62,6 +62,6 @@ class HttpTest extends \PHPUnit_Framework_TestCase
             1
         );
 
-        $this->assertTrue($result instanceof Struct\Error);
+        $this->assertTrue($result instanceof \Exception);
     }
 }

--- a/test/Shopware/Connect/ShopGateway/HttpTest.php
+++ b/test/Shopware/Connect/ShopGateway/HttpTest.php
@@ -33,6 +33,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
      */
     public function testFailOnInvalidResponse($code, $body)
     {
+        $this->expectException(\Exception::class);
         $httpClient = $this->getMock('\\Shopware\\Connect\\HttpClient');
         $httpClient
             ->expects($this->once())
@@ -57,11 +58,9 @@ class HttpTest extends \PHPUnit_Framework_TestCase
             $requestSigner
         );
 
-        $result = $shopGateway->checkProducts(
+        $shopGateway->checkProducts(
             new Struct\Order(),
             1
         );
-
-        $this->assertTrue($result instanceof \Exception);
     }
 }

--- a/test/Shopware/Connect/ShopGateway/HttpTest.php
+++ b/test/Shopware/Connect/ShopGateway/HttpTest.php
@@ -34,7 +34,7 @@ class HttpTest extends \PHPUnit_Framework_TestCase
      */
     public function testFailOnInvalidResponse($code, $body)
     {
-        $this->expectException(\Exception::class);
+        $this->expectException(\RuntimeException::class);
         $httpClient = $this->createMock(HttpClient::class);
         $httpClient
             ->expects($this->once())


### PR DESCRIPTION
Problem if shop is not reachable during checkout ShopGateway::checkProducts
returns an Error Struct but in Shopping service the return value is
used as a Change Array.
An exception was risen because it tried to use an property of
the change struct -> it was hard to debug why this happened
now an exception with an proper message is thrown what helps to debug

to reproduce the problem delete the /etc/hosts entry of your supplier shop in
the shopware vagrant and try to buy a product of that supplier in merchant shop
in both cases the user sees a error because of "technical reasons"
but take a look in the connect log in the merchants backend
and see the difference