### PR TITLE
[CON-4898] replace Common\Struct\Product\ShopItem with Shopware\Connect\Struct\Product

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v2.0.6
+
+Added some new fields to the Shopware\Connect\Struct\Product class which makes
+it available to be used in Shopware Connect's SocialNetwork and Updater instead of the deprecated class
+Bepado\Common\Struct\Product\ShopProduct. The new fields are:
+
+* (int)  $productId
+* (int)  $marketplaceId
+* (Date) $createdAt
+* (array)$suppliersStreams
+
+When checking if a product is a variant product you're encouraged to check, if $groupId is set
+instead of using the old $hasVariants field.
+
 # v2.0.5
 
 Added function in ProductToShop to update the OrderStatus of an order with Connect-Products. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
 # v2.0.6
 
-Added some new fields to the Shopware\Connect\Struct\Product class which makes
+Added some new fields to the `Shopware\Connect\Struct\Product` class which makes
 it available to be used in Shopware Connect's SocialNetwork and Updater instead of the deprecated class
-Bepado\Common\Struct\Product\ShopProduct. The new fields are:
+`Bepado\Common\Struct\Product\ShopProduct`. The new fields are:
 
-* (int)  $productId
-* (int)  $marketplaceId
-* (Date) $createdAt
-* (array)$suppliersStreams
+* `(int)  $productId`
+* `(int)  $marketplaceId`
+* `(Date) $createdAt`
+* `(array)$suppliersStreams`
 
-When checking if a product is a variant product you're encouraged to check, if $groupId is set
-instead of using the old $hasVariants field.
+When checking if a product is a variant product you're encouraged to check, if `$groupId` is set
+instead of using the old `$hasVariants` field.
 
 # v2.0.5
 

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ go to [Releases](https://github.com/shopware/Connect-SDK/releases)
 and download the latest version.
 
 #####Via Composer
-Require the Repo in your composer.json, where "v2.0.5" should be the latest Release.
+Require the Repo in your composer.json, where "v2.0.6" should be the latest Release.
 
       "require": {
-        "shopware/connect-sdk": "dev-master#v2.0.5"
+        "shopware/connect-sdk": "dev-master#v2.0.6"
       },
       "repositories": [
         {

--- a/src/main/Shopware/Connect/SDK.php
+++ b/src/main/Shopware/Connect/SDK.php
@@ -60,7 +60,7 @@ final class SDK
     /**
      * Version constant
      */
-    const VERSION = '2.0.5';
+    const VERSION = '2.0.6';
 
     /**
      * @param string $apiKey API key assigned to you by Shopware Connect

--- a/src/main/Shopware/Connect/Struct/Product.php
+++ b/src/main/Shopware/Connect/Struct/Product.php
@@ -523,7 +523,9 @@ class Product extends ShopItem
             case 'freeDelivery':
                 $val = false; // return by reference hack
                 return $val;
-
+            case 'hasVariants':
+                $val = $this->groupId !== null;
+                return $val;
             default:
                 return parent::__get($property);
         }
@@ -532,8 +534,9 @@ class Product extends ShopItem
     public function __set($property, $value)
     {
         switch ($property) {
-            case 'freeDelivery':
-                // Ignored as of newest version, use $shipping instead
+            // Ignored as of newest version
+            case 'freeDelivery': //use $shipping instead
+            case 'hasVariants': //use groupId !== null
                 break;
             default:
                 return parent::__set($property, $value);

--- a/src/main/Shopware/Connect/Struct/Product.php
+++ b/src/main/Shopware/Connect/Struct/Product.php
@@ -468,6 +468,45 @@ class Product extends ShopItem
     public $customAttribute;
 
     /**
+     * This property is used internally by connect and represents the the id from updater:product
+     *
+     * @var int
+     */
+    public $productId;
+
+    /**
+     * This property is used internally by connect representing the marketplace this product belongs to
+     * default is 1
+     *
+     * @var int
+     */
+    public $marketplaceId;
+
+    /**
+     * indicates when this product was exported to connect the first time
+     *
+     * @var \DateTime
+     */
+    public $createdAt;
+
+    /**
+     * List of streams.
+     *
+     * <code>
+     * <?php
+     *  array(
+     *      "stream-identifier-A" => "stream-name-A",
+     *      "stream-identifier-B" => "stream-name-B",
+     *  )
+     * ?>
+     * </code>
+     *
+     * @var array
+     */
+    public $supplierStreams = [];
+
+
+    /**
      * Restores a product from a previously stored state array.
      *
      * @param array $state

--- a/test/_expectations/MarshalledXml/SimpleClassMapMixed.xml
+++ b/test/_expectations/MarshalledXml/SimpleClassMapMixed.xml
@@ -117,6 +117,18 @@
       <customAttribute>
         <null:null/>
       </customAttribute>
+      <productId>
+        <null:null/>
+      </productId>
+      <marketplaceId>
+        <null:null/>
+      </marketplaceId>
+      <createdAt>
+        <null:null/>
+      </createdAt>
+      <supplierStreams>
+        <array:array/>
+      </supplierStreams>
       <shopId>
         <string:string>f47ac10b-58cc-4372-a567-0e02b2c3d479</string:string>
       </shopId>
@@ -252,6 +264,18 @@
         <customAttribute>
           <null:null/>
         </customAttribute>
+        <productId>
+          <null:null/>
+        </productId>
+        <marketplaceId>
+          <null:null/>
+        </marketplaceId>
+        <createdAt>
+          <null:null/>
+        </createdAt>
+        <supplierStreams>
+          <array:array/>
+        </supplierStreams>
         <shopId>
           <string:string>f47ac10b-58cc-4372-a567-0e02b2c3d479</string:string>
         </shopId>

--- a/test/_expectations/MarshalledXml/SimpleClassMapProduct.xml
+++ b/test/_expectations/MarshalledXml/SimpleClassMapProduct.xml
@@ -117,6 +117,18 @@
       <customAttribute>
         <null:null/>
       </customAttribute>
+      <productId>
+        <null:null/>
+      </productId>
+      <marketplaceId>
+        <null:null/>
+      </marketplaceId>
+      <createdAt>
+        <null:null/>
+      </createdAt>
+      <supplierStreams>
+        <array:array/>
+      </supplierStreams>
       <shopId>
         <string:string>f47ac10b-58cc-4372-a567-0e02b2c3d479</string:string>
       </shopId>


### PR DESCRIPTION
Added some fields that are used in connect which are defined in the old SopItem class but not in the SDK version. this fields are used when unserialising from the updaters database